### PR TITLE
Fix azurerm_private_endpoint validation rejecting empty request_message for manual connections

### DIFF
--- a/.github/workflows/comment-ci-failure-outdated.yaml
+++ b/.github/workflows/comment-ci-failure-outdated.yaml
@@ -11,19 +11,22 @@ jobs:
   comment-ci-failure-outdated:
     runs-on: ubuntu-latest
     steps:
-      - name: Minimize outdated failure comments
+      - name: Strike through fixed failure and clean up
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
+          retries: 3
           script: |
             const workflowName = '${{ github.workflow }}';
+            const sha = '${{ github.event.pull_request.head.sha }}';
+            const shortSha = sha.substring(0, 7);
             const prNumber = ${{ github.event.number }};
-            const marker = `<b>Build failure: ${workflowName}</b>`;
 
-            console.log(`==> Checking PR #${prNumber} for outdated "${workflowName}" failure comments...`);
-            console.log(`    Marker: ${marker}`);
+            console.log(`=== Comment Cleanup: "${workflowName}" ===`);
+            console.log(`PR #${prNumber}, commit ${shortSha} (${sha})`);
 
-            // Use GraphQL to fetch comments with isMinimized status, paginating through all
+            // Fetch all comments using GraphQL for minimize capability
+            console.log(`Fetching PR comments via GraphQL...`);
             const query = `
               query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
                 repository(owner: $owner, name: $repo) {
@@ -46,15 +49,15 @@ jobs:
               }
             `;
 
+            // Collect all non-minimized failure comments
             let cursor = null;
             let hasNextPage = true;
-            let totalComments = 0;
-            let botComments = 0;
-            let matchingComments = 0;
-            let minimizedCount = 0;
-            let alreadyHiddenCount = 0;
+            const failureComments = [];
+            let totalFetched = 0;
+            let pageCount = 0;
 
             while (hasNextPage) {
+              pageCount++;
               const result = await github.graphql(query, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -65,43 +68,104 @@ jobs:
               const { nodes, pageInfo } = result.repository.pullRequest.comments;
               hasNextPage = pageInfo.hasNextPage;
               cursor = pageInfo.endCursor;
-              totalComments += nodes.length;
+              totalFetched += nodes.length;
 
               for (const comment of nodes) {
-                // Only target comments left by the github-actions bot.
                 // GraphQL returns author.login as 'github-actions' while the REST API
                 // returns it as 'github-actions[bot]'. Using startsWith to handle both.
                 if (!comment.author.login.startsWith('github-actions')) continue;
-                botComments++;
+                if (!comment.body) continue;
+                if (comment.isMinimized) continue;
 
-                if (!comment.body || !comment.body.includes(marker)) continue;
-                matchingComments++;
-
-                // Skip comments that are already minimized
-                if (comment.isMinimized) {
-                  alreadyHiddenCount++;
-                  const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}#issuecomment-${comment.databaseId}`;
-                  console.log(`    Already hidden: ${url}`);
-                  continue;
+                if (comment.body.includes('CI Build Failures for')) {
+                  failureComments.push(comment);
                 }
+              }
+            }
 
+            console.log(`Fetched ${totalFetched} comments across ${pageCount} page(s)`);
+            console.log(`Found ${failureComments.length} active (non-minimized) failure comment(s)`);
+
+            // Process ALL non-minimized failure comments for this workflow
+            let struckCount = 0;
+            for (const comment of failureComments) {
+              const hasActiveLine = comment.body.split('\n').some(line =>
+                line.trim().startsWith('- ❌') &&
+                line.includes(`<b>${workflowName}</b>`) &&
+                !line.includes('<del>')
+              );
+              if (!hasActiveLine) continue;
+
+              console.log(`\n--- Processing comment (id: ${comment.databaseId}) ---`);
+
+              // Strike through the line for this workflow
+              const lines = comment.body.split('\n');
+              const updatedLines = lines.map(line => {
+                if (line.trim().startsWith('- ❌') &&
+                    line.includes(`<b>${workflowName}</b>`) &&
+                    !line.includes('<del>')) {
+                  console.log(`Striking through: ${line.trim().substring(0, 60)}...`);
+                  return `- <del>${line.trim().substring(2)}</del>`;
+                }
+                return line;
+              });
+
+              // Count remaining active failures in this comment
+              const activeFailures = updatedLines.filter(l =>
+                l.trim().startsWith('- ❌') && !l.includes('<del>')
+              ).length;
+              const totalFailures = updatedLines.filter(l =>
+                l.trim().startsWith('- ❌') || l.trim().startsWith('- <del>')
+              ).length;
+
+              console.log(`Failure count: ${activeFailures} active / ${totalFailures} total`);
+
+              // Update counter line
+              let body;
+              if (activeFailures === 0) {
+                console.log(`All failures resolved in this comment — updating counter to "All jobs have been fixed!"`);
+                body = updatedLines.join('\n').replace(
+                  /^(?:\d+(?:\/\d+)?\s+job.*:|All jobs have been fixed.*$)/m,
+                  `All jobs have been fixed! ✅`
+                );
+              } else {
+                const counterText = `${activeFailures}/${totalFailures} jobs still failing:`;
+                console.log(`Updating counter to "${counterText}"`);
+                body = updatedLines.join('\n').replace(
+                  /^(?:\d+(?:\/\d+)?\s+job.*:|All jobs have been fixed.*$)/m,
+                  counterText
+                );
+              }
+
+              // Update the comment
+              await github.rest.issues.updateComment({
+                comment_id: comment.databaseId,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+              struckCount++;
+              console.log(`✅ Struck through "${workflowName}" in comment (id: ${comment.databaseId})`);
+
+              // If all failures in this comment are resolved, minimize it
+              if (activeFailures === 0) {
+                console.log(`All failures resolved — minimizing comment (id: ${comment.databaseId})...`);
                 await github.graphql(`
                   mutation($id: ID!) {
                     minimizeComment(input: {
                       subjectId: $id,
-                      classifier: OUTDATED
+                      classifier: RESOLVED
                     }) {
-                      minimizedComment {
-                        isMinimized
-                      }
+                      minimizedComment { isMinimized }
                     }
                   }
                 `, { id: comment.id });
-
-                minimizedCount++;
-                const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}#issuecomment-${comment.databaseId}`;
-                console.log(`    Minimized: ${url}`);
+                console.log(`✅ Minimized resolved comment (id: ${comment.databaseId})`);
               }
             }
 
-            console.log(`==> Done. Scanned ${totalComments} comments: ${botComments} from bot, ${matchingComments} matching "${workflowName}", ${minimizedCount} newly minimized, ${alreadyHiddenCount} already hidden.`);
+            if (struckCount === 0) {
+              console.log(`✅ No active failure line found for "${workflowName}" in any comment — nothing to strike through`);
+            } else {
+              console.log(`\n✅ Done — struck through "${workflowName}" in ${struckCount} comment(s)`);
+            }

--- a/.github/workflows/comment-ci-failure.yaml
+++ b/.github/workflows/comment-ci-failure.yaml
@@ -14,12 +14,21 @@ jobs:
       - name: Get run url
         run: |
           echo "gha_url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}" >> $GITHUB_ENV
-      - name: Send build failure comment
+      - name: Add failure to unified build comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
+          retries: 3
           script: |
             const workflowName = '${{ github.workflow }}';
+            const sha = '${{ github.event.pull_request.head.sha }}';
+            const shortSha = sha.substring(0, 7);
+            const runUrl = '${{ env.gha_url }}';
+            const prNumber = ${{ github.event.number }};
+
+            console.log(`=== Comment Failure: "${workflowName}" ===`);
+            console.log(`PR #${prNumber}, commit ${shortSha} (${sha})`);
+            console.log(`Run URL: ${runUrl}`);
 
             const guidance = {
               'Vendor Dependencies Check': 'Do not modify files in the `vendor/` directory directly. Instead, update dependencies in `go.mod` and run `go mod vendor` to sync the vendor directory. Then run `make depscheck` locally to verify.',
@@ -30,20 +39,129 @@ jobs:
               'Unit Tests': 'Run `make test` locally to reproduce and fix the failing unit tests.',
               'ShellCheck Scripts': 'Run `make shellcheck` locally to check shell scripts for issues and fix any warnings or errors.',
               'Validate Examples': 'Run `make validate-examples` locally to check that your example Terraform configurations under `examples/` are valid.',
-
+              'Provider Tests': 'Run `make testacc TEST=./internal/provider TESTARGS="-run \'^TestAcc\'"` locally to reproduce and fix the failing provider tests.',
+              'Check for new usages of deprecated functionality': 'Your changes introduce new usages of deprecated functions or patterns. Please use the recommended replacements instead.',
+              'Preview ARM API Version Linter': 'Your changes reference Azure ARM API versions that are in preview. Please update the API version references to use GA (stable) versions.',
             };
 
-            let body = `<b>Build failure: ${workflowName}</b>\n\nThis pull request contains a build failure in the <b>${workflowName}</b> check which needs to be addressed [here](${{ env.gha_url }}).`;
+            const commitUrl = `https://github.com/${{ github.repository }}/commit/${sha}`;
+            const marker = `CI Build Failures for <a href="${commitUrl}"><code>${shortSha}</code></a>`;
+            const guideText = guidance[workflowName] || 'Check the logs for details on the failure.';
+            const failureLine = `- ❌ <b>${workflowName}</b> — ${guideText} (<a href="${runUrl}">logs</a>)`;
 
-            if (guidance[workflowName]) {
-              body += `\n\n<b>How to fix:</b> ${guidance[workflowName]}`;
+            if (!guidance[workflowName]) {
+              console.log(`⚠️  No guidance text found for workflow "${workflowName}", using default`);
             }
 
-            body += `\n\nFor more information, please refer to our [Contributing Guide](https://github.com/${{ github.repository }}/blob/main/contributing/README.md).`;
+            const footer = `\n\nFor more information, please refer to our <a href="https://github.com/${{ github.repository }}/blob/main/contributing/README.md">Contributing Guide</a>.`;
 
-            github.rest.issues.createComment({
-              issue_number: ${{ github.event.number }},
+            // Find existing unified comment for this commit
+            console.log(`Searching for existing unified comment with marker: "${marker}"`);
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
-            })
+              per_page: 100,
+            });
+
+            const botComments = comments.filter(c => c.user.login === 'github-actions[bot]');
+            console.log(`Found ${comments.length} total comments, ${botComments.length} from github-actions[bot]`);
+
+            const botComment = botComments.find(c => c.body && c.body.includes('CI Build Failures for') && c.body.includes(`<code>${shortSha}</code>`));
+
+            if (botComment) {
+              console.log(`Found existing unified comment (id: ${botComment.id}) for commit ${shortSha}`);
+
+              let body = botComment.body;
+
+              const activeLinePattern = `- ❌ <b>${workflowName}</b>`;
+              const struckLinePattern = `- <del>❌ <b>${workflowName}</b>`;
+
+              if (body.includes(struckLinePattern)) {
+                console.log(`"${workflowName}" was previously struck through (fixed) — removing old line and re-adding as active failure`);
+                const lines = body.split('\n');
+                const filtered = lines.filter(line => {
+                  const trimmed = line.trim();
+                  return !(trimmed.startsWith('- <del>') && trimmed.includes(`<b>${workflowName}</b>`));
+                });
+                body = filtered.join('\n');
+                // Fall through to insert the new failure line below
+              } else if (body.includes(activeLinePattern)) {
+                console.log(`"${workflowName}" already has an active failure line — updating log URL`);
+                const lines = body.split('\n');
+                const updated = lines.map(line => {
+                  if (line.includes(`<b>${workflowName}</b>`) && !line.includes('<del>')) {
+                    return failureLine;
+                  }
+                  return line;
+                });
+                body = updated.join('\n');
+
+                body = updateCounter(body);
+
+                await github.rest.issues.updateComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body,
+                });
+                console.log(`✅ Updated log URL for "${workflowName}" in unified comment`);
+                return;
+              } else {
+                console.log(`"${workflowName}" is a new failure — adding to existing comment`);
+              }
+
+              // Insert the new failure line before the footer
+              const footerIndex = body.lastIndexOf('\n\nFor more information');
+              if (footerIndex !== -1) {
+                body = body.substring(0, footerIndex) + '\n' + failureLine + body.substring(footerIndex);
+                console.log(`Inserted failure line before footer`);
+              } else {
+                body += '\n' + failureLine;
+                console.log(`⚠️  Footer not found, appended failure line to end`);
+              }
+
+              body = updateCounter(body);
+
+              await github.rest.issues.updateComment({
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+              console.log(`✅ Added "${workflowName}" failure to existing unified comment (id: ${botComment.id})`);
+            } else {
+              console.log(`No existing unified comment found for commit ${shortSha} — creating new one`);
+
+              const body = `<b>${marker}</b>\n\n` +
+                `1 job has failed and needs to be addressed:\n\n` +
+                failureLine +
+                footer;
+
+              const { data: newComment } = await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+              console.log(`✅ Created unified failure comment (id: ${newComment.id}) for "${workflowName}" at commit ${shortSha}`);
+            }
+
+            function updateCounter(body) {
+              const lines = body.split('\n');
+              const activeFailures = lines.filter(l =>
+                l.trim().startsWith('- ❌') && !l.includes('<del>')
+              ).length;
+              const totalFailures = lines.filter(l =>
+                (l.trim().startsWith('- ❌') || (l.trim().startsWith('- <del>')))
+              ).length;
+
+              const counterText = activeFailures === totalFailures
+                ? `${activeFailures} job${activeFailures === 1 ? ' has' : 's have'} failed and need${activeFailures === 1 ? 's' : ''} to be addressed:`
+                : `${activeFailures}/${totalFailures} jobs still failing:`;
+
+              console.log(`Counter update: ${activeFailures} active / ${totalFailures} total → "${counterText}"`);
+
+              // Replace the counter line
+              return body.replace(/^(?:\d+(?:\/\d+)?\s+job.*:|All jobs have been fixed.*$)/m, counterText);
+            }

--- a/.github/workflows/run-team-city-tests-on-comment.yaml
+++ b/.github/workflows/run-team-city-tests-on-comment.yaml
@@ -92,13 +92,31 @@ jobs:
         run: |
           go install github.com/katbyte/tctest@latest
 
+      - name: Get PR commit SHA
+        id: get-pr-sha
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            const sha = pr.data.head.sha;
+            core.setOutput('sha', sha);
+            core.info(`PR head SHA: ${sha}`);
+            return sha;
+
       - name: Run tctest
+        id: run-tctest
         run: |
           PR_NUMBER=${{ github.event.issue.number }}
           COMMENT_BODY="${{ github.event.comment.body }}"
+          PR_SHA="${{ steps.get-pr-sha.outputs.sha }}"
           echo "Running tctest for PR #${PR_NUMBER}"
-          tctest pr ${PR_NUMBER} --properties "POST_GITHUB_COMMENT=true"
-
+          echo "PR commit SHA: ${PR_SHA}"
+          tctest pr ${PR_NUMBER} -c --properties "TRACKING_ID=${PR_SHA}"
       - name: Comment on success
         if: success()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -140,31 +158,4 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: '⚠️ You are not authorized to run tests. Only members of the designated team can trigger test runs.'
-            });
-
-  minimize-comment-as-outdated:
-    runs-on: ubuntu-latest
-    needs: [run-tests, unauthorized-comment]
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/test')
-    steps:
-      - name: Minimize triggering comment as outdated
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const mutation = `
-              mutation($subjectId: ID!) {
-                minimizeComment(input: {subjectId: $subjectId, classifier: OUTDATED}) {
-                  minimizedComment {
-                    isMinimized
-                    minimizedReason
-                  }
-                }
-              }
-            `;
-
-            const commentNodeId = context.payload.comment.node_id;
-
-            await github.graphql(mutation, {
-              subjectId: commentNodeId
             });

--- a/.teamcity/components/build_azure.kt
+++ b/.teamcity/components/build_azure.kt
@@ -49,5 +49,5 @@ fun ParametrizedWithType.ConfigureAzureSpecificTestParameters(environment: Strin
     hiddenPasswordVariable("env.GIT_PAT", config.gitPat, "Personal Access Token for GitHub")
     hiddenVariable("env.GITHUB_REPO", config.gitHubRepo, "GitHub Repository")
     hiddenVariable("env.POST_GITHUB_COMMENT",  "false", "Whether to post a comment on the PR with the results of the tests")
-    hiddenVariable("env.POST_GITHUB_COMMENT_DETAILED",  "false", "Whether to post a detailed comment on the PR with the results of the tests")
+    hiddenVariable("env.TRACKING_ID",  "0", "Tracking id for the comments posted by the build")
 }

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -34,8 +34,12 @@ fun BuildSteps.ConfigureGoEnv() {
     step(ScriptBuildStep {
         name = "Configure Go Version"
         scriptContent = """
-                        echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='$(date +%s)']"
-                        goenv install -s $(goenv local) && goenv rehash
+                        BUILD_TIME=$(date +%s)
+                        echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='${'$'}BUILD_TIME']"
+
+                        GO_VERSION=$(goenv local)
+                        goenv install -s "${'$'}GO_VERSION"
+                        goenv rehash
                         """.trimIndent()
     })
 }

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -35,7 +35,7 @@ fun BuildSteps.ConfigureGoEnv() {
         name = "Configure Go Version"
         scriptContent = """
                         echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='$(date +%s)']"
-                        goenv install -s \$(goenv local) && goenv rehash
+                        goenv install -s $(goenv local) && goenv rehash
                         """.trimIndent()
     })
 }

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -30,10 +30,17 @@ fun BuildFeatures.BuildCacheFeature() {
         })
 }
 
+fun BuildSteps.SetBuildStartTime() {
+    step(ScriptBuildStep {
+        name = "Set Build Start Time"
+        scriptContent = File("scripts/set_build_start_time.sh").readText()
+    })
+}
+
 fun BuildSteps.ConfigureGoEnv() {
     step(ScriptBuildStep {
         name = "Configure Go Version"
-        scriptContent = File("scripts/configure_go_version.sh").readText()
+        scriptContent = "goenv install -s \$(goenv local) && goenv rehash"
     })
 }
 

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -33,7 +33,10 @@ fun BuildFeatures.BuildCacheFeature() {
 fun BuildSteps.ConfigureGoEnv() {
     step(ScriptBuildStep {
         name = "Configure Go Version"
-        scriptContent = "goenv install -s \$(goenv local) && goenv rehash"
+        scriptContent = """
+                        echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='$(date +%s)']"
+                        goenv install -s \$(goenv local) && goenv rehash
+                        """.trimIndent()
     })
 }
 
@@ -119,7 +122,7 @@ fun ParametrizedWithType.TerraformAcceptanceTestParameters(parallelism : Int, pr
     text("TEST_PREFIX", prefix)
     text("TIMEOUT", "%d".format(timeout))
     text("POST_GITHUB_COMMENT", "false")
-    text("POST_GITHUB_COMMENT_DETAILED", "false")
+    text("TRACKING_ID", "0", "Tracking ID for comment management (typically PR commit SHA)")
 }
 
 fun ParametrizedWithType.ReadOnlySettings() {
@@ -141,6 +144,10 @@ fun ParametrizedWithType.TerraformShouldPanicForSchemaErrors() {
 
 fun ParametrizedWithType.WorkingDirectory(packageName: String) {
     text("SERVICE_PATH", servicePath(packageName), "", "The path at which to run - automatically updated", ParameterDisplay.HIDDEN)
+}
+
+fun ParametrizedWithType.BuildStartTime() {
+    text("env.BUILD_START_TIME", "1777662664", "The time at which the build started")
 }
 
 fun ParametrizedWithType.GoCache() {

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -33,14 +33,7 @@ fun BuildFeatures.BuildCacheFeature() {
 fun BuildSteps.ConfigureGoEnv() {
     step(ScriptBuildStep {
         name = "Configure Go Version"
-        scriptContent = """
-                        BUILD_TIME=$(date +%s)
-                        echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='${'$'}BUILD_TIME']"
-
-                        GO_VERSION=$(goenv local)
-                        goenv install -s "${'$'}GO_VERSION"
-                        goenv rehash
-                        """.trimIndent()
+        scriptContent = File("scripts/configure_go_version.sh").readText()
     })
 }
 

--- a/.teamcity/components/build_config_cache.kt
+++ b/.teamcity/components/build_config_cache.kt
@@ -64,6 +64,7 @@ class buildCacheConfiguration(environment: String, vcsRootId: String) {
 
             params {
                 GoCache()
+                BuildStartTime()
                 ReadOnlySettings()
             }
         }

--- a/.teamcity/components/build_config_cache.kt
+++ b/.teamcity/components/build_config_cache.kt
@@ -64,7 +64,6 @@ class buildCacheConfiguration(environment: String, vcsRootId: String) {
 
             params {
                 GoCache()
-                BuildStartTime()
                 ReadOnlySettings()
             }
         }

--- a/.teamcity/components/build_config_pull_request.kt
+++ b/.teamcity/components/build_config_pull_request.kt
@@ -43,6 +43,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
                 TerraformCoreBinaryTesting()
                 ReadOnlySettings()
                 GoCache()
+                BuildStartTime()
 
                 text("SERVICES", "portal")
             }

--- a/.teamcity/components/build_config_pull_request.kt
+++ b/.teamcity/components/build_config_pull_request.kt
@@ -21,7 +21,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
             steps {
                 var packageName = "\"%SERVICES%\""
 
-                SetBuildStartTime()
+                // SetBuildStartTime()
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunAcceptanceTestsForPullRequest(packageName)

--- a/.teamcity/components/build_config_pull_request.kt
+++ b/.teamcity/components/build_config_pull_request.kt
@@ -21,6 +21,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
             steps {
                 var packageName = "\"%SERVICES%\""
 
+                SetBuildStartTime()
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunAcceptanceTestsForPullRequest(packageName)

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -43,6 +43,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
                 ReadOnlySettings()
                 WorkingDirectory(packageName)
                 GoCache()
+                BuildStartTime()
             }
 
             triggers {

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -19,7 +19,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
             }
 
             steps {
-                SetBuildStartTime()
+                // SetBuildStartTime()
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunAcceptanceTests(packageName)

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -19,6 +19,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
             }
 
             steps {
+                SetBuildStartTime()
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunAcceptanceTests(packageName)

--- a/.teamcity/scripts/configure_go_version.sh
+++ b/.teamcity/scripts/configure_go_version.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-BUILD_TIME=$(date +%s)
-echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='$BUILD_TIME']"
-
-GO_VERSION=$(goenv local)
-goenv install -s "$GO_VERSION"
-goenv rehash

--- a/.teamcity/scripts/configure_go_version.sh
+++ b/.teamcity/scripts/configure_go_version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BUILD_TIME=$(date +%s)
+echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='$BUILD_TIME']"
+
+GO_VERSION=$(goenv local)
+goenv install -s "$GO_VERSION"
+goenv rehash

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 POST_GITHUB_COMMENT="%POST_GITHUB_COMMENT%"
-POST_GITHUB_COMMENT_DETAILED="%POST_GITHUB_COMMENT_DETAILED%"
 
-if [ "$POST_GITHUB_COMMENT" != "true" ] && [ "$POST_GITHUB_COMMENT_DETAILED" != "true" ]; then
+if [ "$POST_GITHUB_COMMENT" != "true" ]; then
   echo "GitHub commenting disabled — skipping."
   exit 0
 fi
@@ -17,13 +16,18 @@ else
   exit 0
 fi
 
-detailed=false
-#if [ "$POST_GITHUB_COMMENT_DETAILED" = "true" ]; then
-#  echo "Detailed GitHub commenting enabled."
-#  detailed=true
-#fi
+TRACKING_ID="%TRACKING_ID%"
+echo "Tracking ID: $TRACKING_ID"
 
 BUILD_ID="%teamcity.build.id%"
+
+github_api_request() {
+  local endpoint="$1"
+  curl -s \
+    -H "Authorization: Bearer %env.GIT_PAT%" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/%env.GITHUB_REPO%${endpoint}"
+}
 
 TEST_RESULTS=$(file="results.txt"
 
@@ -69,38 +73,26 @@ awk '
 ' "$file"
 )
 
-
-
-# Parse results to get counts
 PASS_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' '{if($2=="PASS") print}' | wc -l | tr -d ' ')
 FAIL_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' '{if($2=="FAIL") print}' | wc -l | tr -d ' ')
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 
-# Fetch PR author if there are failures
-PREFIX=""
-if [ "$FAIL_COUNT" -gt 0 ]; then
-  PR_AUTHOR=$(curl -s \
-    -H "Authorization: Bearer %env.GIT_PAT%" \
-    -H "Accept: application/vnd.github+json" \
-    https://api.github.com/repos/%env.GITHUB_REPO%/pulls/"${PR_NUMBER}" \
-    | jq -r '.user.login')
+# BUILD_START_TIME is set in the first build step: $(date +%s)
+BUILD_START_TIME="%env.BUILD_START_TIME%"
+CURRENT_TIME_S=$(date +%s)
+BUILD_DURATION=$((CURRENT_TIME_S - BUILD_START_TIME))
 
-  if [ -z "$PR_AUTHOR" ] || [ "$PR_AUTHOR" = "null" ]; then
-    echo "Warning: Could not fetch PR author"
-  else
-    PREFIX="@${PR_AUTHOR} - One or more tests failed in this PR. Please review the failures.
+BUILD_HOURS=$((BUILD_DURATION / 3600))
+BUILD_MINUTES=$(((BUILD_DURATION % 3600) / 60))
+BUILD_SECONDS=$((BUILD_DURATION % 60))
 
-"
-  fi
-fi
-
-# Build GitHub comment
-COMMENT="${PREFIX}Build: [$BUILD_ID](%teamcity.serverUrl%/viewLog.html?buildId=$BUILD_ID)
+COMMENT="Build: [$BUILD_ID](%teamcity.serverUrl%/viewLog.html?buildId=$BUILD_ID)
 PR: #$PR_NUMBER
 
 **Total:** $TOTAL
 **Passed:** $PASS_COUNT
 **Failed:** $FAIL_COUNT
+**Test Duration:** ${BUILD_HOURS}h ${BUILD_MINUTES}m ${BUILD_SECONDS}s
 
 <details>
 <summary>Test Details</summary>
@@ -130,15 +122,7 @@ record != "" {
     if (status == "PASS") {
         print "<tr><td>✅ PASS</td><td>" test_name "</td><td>" duration "s</td></tr>"
     } else if (status == "FAIL") {
-        if (detailed == "true") {
-            # Escape HTML special chars
-            gsub(/&/, "\\&", output)
-            gsub(/</, "\\<", output)
-            gsub(/>/, "\\>", output)
-            print "<tr><td>❌ FAIL</td><td>" test_name "<br/><details><summary>Error Details</summary><pre><code>" output "</code></pre></details></td><td>" duration "s</td></tr>"
-        } else {
-            print "<tr><td>❌ FAIL</td><td>" test_name "</td><td>" duration "s</td></tr>"
-        }
+        print "<tr><td>❌ FAIL</td><td>" test_name "</td><td>" duration "s</td></tr>"
     }
 }
 ')
@@ -149,10 +133,75 @@ COMMENT+="</table>
 </details>
 "
 
-echo "Posting comment to GitHub..."
+# Fetch PR author if there are failures
+AUTHOR_MESSAGE=""
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  PR_AUTHOR=$(github_api_request "/pulls/${PR_NUMBER}" \
+  | jq -r '.user.login')
 
-curl -s \
--H "Authorization: Bearer %env.GIT_PAT%" \
--H "Accept: application/vnd.github+json" \
-https://api.github.com/repos/%env.GITHUB_REPO%/issues/"${PR_NUMBER}"/comments \
--d "{\"body\": $(jq -Rs . <<< "$COMMENT")}"
+  if [ -z "$PR_AUTHOR" ] || [ "$PR_AUTHOR" = "null" ]; then
+    echo "Warning: Could not fetch PR author"
+  else
+    AUTHOR_MESSAGE="@${PR_AUTHOR} - One or more tests failed in this PR. Please review the failures.
+    "
+  fi
+fi
+
+# Add a unique identifier to track comments from this script
+# Include tracking ID (hidden in HTML comment) to prevent minimizing current run's comments
+COMMENT_IDENTIFIER="<!-- teamcity-test-results -->"
+
+TRACKING_COMMENT=""
+if [ "$TRACKING_ID" != "0" ]; then
+  TRACKING_COMMENT="<!-- tracking-id:${TRACKING_ID} -->"
+fi
+
+COMMENT="${COMMENT_IDENTIFIER}
+${TRACKING_COMMENT}
+${AUTHOR_MESSAGE}
+${COMMENT}"
+
+echo "Fetching existing comments..."
+COMMENTS_JSON=$(github_api_request "/issues/${PR_NUMBER}/comments")
+
+# Filter comments that should be minimized (teamcity-test-results or /test comments)
+# but exclude those with the current tracking ID
+COMMENT_IDS=$(echo "$COMMENTS_JSON" | jq -r --arg tracking_id "$TRACKING_ID" '
+  .[] |
+  select(.body | type == "string" and (contains("<!-- teamcity-test-results -->") or startswith("/test"))) |
+  select(.body | contains("tracking-id:" + $tracking_id) | not) |
+  .node_id
+' 2>&1 | grep -v "^jq:")
+
+if [ -n "$COMMENT_IDS" ]; then
+  echo "Found previous comments to minimize"
+  while IFS= read -r COMMENT_NODE_ID; do
+    if [ -n "$COMMENT_NODE_ID" ]; then
+      echo "Minimizing comment: $COMMENT_NODE_ID"
+      RESPONSE=$(curl -s -X POST \
+        -H "Authorization: bearer %env.GIT_PAT%" \
+        -H "Content-Type: application/json" \
+        https://api.github.com/graphql \
+        -d "{\"query\": \"mutation { minimizeComment(input: {subjectId: \\\"$COMMENT_NODE_ID\\\", classifier: OUTDATED}) { minimizedComment { isMinimized } } }\"}")
+
+      # Check if minimization was successful
+      if echo "$RESPONSE" | jq -e '.data.minimizeComment.minimizedComment.isMinimized' > /dev/null 2>&1; then
+        echo "Successfully minimized comment: $COMMENT_NODE_ID"
+      else
+        echo "Warning: Failed to minimize comment: $COMMENT_NODE_ID"
+        echo "Response: $RESPONSE"
+      fi
+    fi
+  done <<< "$COMMENT_IDS"
+else
+  echo "No previous comments found to minimize"
+fi
+
+echo "Posting new comment to GitHub..."
+
+curl -s -X POST \
+  -H "Authorization: Bearer %env.GIT_PAT%" \
+  -H "Accept: application/vnd.github+json" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/%env.GITHUB_REPO%/issues/${PR_NUMBER}/comments" \
+  -d "{\"body\": $(jq -Rs . <<< "$COMMENT")}"

--- a/.teamcity/scripts/set_build_start_time.sh
+++ b/.teamcity/scripts/set_build_start_time.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "##teamcity[setParameter name='env.BUILD_START_TIME' value='$(date +%s)']"

--- a/internal/services/costmanagement/resource_group_cost_management_view_resource.go
+++ b/internal/services/costmanagement/resource_group_cost_management_view_resource.go
@@ -4,6 +4,14 @@
 package costmanagement
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	resourceValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
@@ -13,6 +21,19 @@ import (
 
 type ResourceGroupCostManagementViewResource struct {
 	base costManagementViewBaseResource
+}
+
+type ResourceGroupCostManagementViewModel struct {
+	Name            string                           `tfschema:"name"`
+	ResourceGroupId string                           `tfschema:"resource_group_id"`
+	DisplayName     string                           `tfschema:"display_name"`
+	ChartType       string                           `tfschema:"chart_type"`
+	Accumulated     bool                             `tfschema:"accumulated"`
+	ReportType      string                           `tfschema:"report_type"`
+	Timeframe       string                           `tfschema:"timeframe"`
+	Dataset         []CostManagementViewDatasetModel `tfschema:"dataset"`
+	Kpi             []CostManagementViewKpiModel     `tfschema:"kpi"`
+	Pivot           []CostManagementViewPivotModel   `tfschema:"pivot"`
 }
 
 var _ sdk.Resource = ResourceGroupCostManagementViewResource{}
@@ -40,7 +61,7 @@ func (r ResourceGroupCostManagementViewResource) Attributes() map[string]*plugin
 }
 
 func (r ResourceGroupCostManagementViewResource) ModelObject() interface{} {
-	return nil
+	return &ResourceGroupCostManagementViewModel{}
 }
 
 func (r ResourceGroupCostManagementViewResource) ResourceType() string {
@@ -52,11 +73,106 @@ func (r ResourceGroupCostManagementViewResource) IDValidationFunc() pluginsdk.Sc
 }
 
 func (r ResourceGroupCostManagementViewResource) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			var config ResourceGroupCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := views.NewScopedViewID(config.ResourceGroupId, config.Name)
+
+			existing, err := client.GetByScope(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			accumulated := views.AccumulatedTypeFalse
+			if config.Accumulated {
+				accumulated = views.AccumulatedTypeTrue
+			}
+
+			props := views.View{
+				Properties: &views.ViewProperties{
+					Accumulated: pointer.To(accumulated),
+					DisplayName: pointer.To(config.DisplayName),
+					Chart:       pointer.To(views.ChartType(config.ChartType)),
+					Query: &views.ReportConfigDefinition{
+						DataSet:   expandDatasetFromModel(config.Dataset),
+						Timeframe: views.ReportTimeframeType(config.Timeframe),
+						Type:      views.ReportTypeUsage,
+					},
+					Kpis:   expandKpisFromModel(config.Kpi),
+					Pivots: expandPivotsFromModel(config.Pivot),
+				},
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r ResourceGroupCostManagementViewResource) Read() sdk.ResourceFunc {
-	return r.base.readFunc("resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := ResourceGroupCostManagementViewModel{
+				Name:            id.ViewName,
+				ResourceGroupId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					state.ChartType = pointer.FromEnum(props.Chart)
+					state.DisplayName = pointer.From(props.DisplayName)
+
+					state.Accumulated = views.AccumulatedTypeTrue == pointer.From(props.Accumulated)
+
+					state.Kpi = flattenKpisToModel(props.Kpis)
+					state.Pivot = flattenPivotsToModel(props.Pivots)
+
+					if query := props.Query; query != nil {
+						state.Timeframe = string(query.Timeframe)
+						state.ReportType = string(query.Type)
+						if query.DataSet != nil {
+							state.Dataset = flattenDatasetToModel(query.DataSet)
+						}
+					}
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r ResourceGroupCostManagementViewResource) Delete() sdk.ResourceFunc {
@@ -64,5 +180,67 @@ func (r ResourceGroupCostManagementViewResource) Delete() sdk.ResourceFunc {
 }
 
 func (r ResourceGroupCostManagementViewResource) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config ResourceGroupCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Update operation requires latest eTag to be set in the request.
+			existing, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			model := existing.Model
+
+			if model != nil {
+				if model.ETag == nil {
+					return fmt.Errorf("add %s: etag was nil", *id)
+				}
+			}
+
+			if model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+			}
+
+			if metadata.ResourceData.HasChange("display_name") {
+				model.Properties.DisplayName = pointer.To(config.DisplayName)
+			}
+
+			if metadata.ResourceData.HasChange("chart_type") {
+				model.Properties.Chart = pointer.To(views.ChartType(config.ChartType))
+			}
+
+			if metadata.ResourceData.HasChange("dataset") {
+				model.Properties.Query.DataSet = expandDatasetFromModel(config.Dataset)
+			}
+
+			if metadata.ResourceData.HasChange("timeframe") {
+				model.Properties.Query.Timeframe = views.ReportTimeframeType(config.Timeframe)
+			}
+
+			if metadata.ResourceData.HasChange("kpi") {
+				model.Properties.Kpis = expandKpisFromModel(config.Kpi)
+			}
+
+			if metadata.ResourceData.HasChange("pivot") {
+				model.Properties.Pivots = expandPivotsFromModel(config.Pivot)
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, *id, *model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/internal/services/costmanagement/subscription_cost_management_view_resource.go
+++ b/internal/services/costmanagement/subscription_cost_management_view_resource.go
@@ -4,7 +4,15 @@
 package costmanagement
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -13,6 +21,19 @@ import (
 
 type SubscriptionCostManagementViewResource struct {
 	base costManagementViewBaseResource
+}
+
+type SubscriptionCostManagementViewModel struct {
+	Name        string                           `tfschema:"name"`
+	SubId       string                           `tfschema:"subscription_id"`
+	DisplayName string                           `tfschema:"display_name"`
+	ChartType   string                           `tfschema:"chart_type"`
+	Accumulated bool                             `tfschema:"accumulated"`
+	ReportType  string                           `tfschema:"report_type"`
+	Timeframe   string                           `tfschema:"timeframe"`
+	Dataset     []CostManagementViewDatasetModel `tfschema:"dataset"`
+	Kpi         []CostManagementViewKpiModel     `tfschema:"kpi"`
+	Pivot       []CostManagementViewPivotModel   `tfschema:"pivot"`
 }
 
 var _ sdk.Resource = SubscriptionCostManagementViewResource{}
@@ -40,7 +61,7 @@ func (r SubscriptionCostManagementViewResource) Attributes() map[string]*plugins
 }
 
 func (r SubscriptionCostManagementViewResource) ModelObject() interface{} {
-	return nil
+	return &SubscriptionCostManagementViewModel{}
 }
 
 func (r SubscriptionCostManagementViewResource) ResourceType() string {
@@ -52,11 +73,106 @@ func (r SubscriptionCostManagementViewResource) IDValidationFunc() pluginsdk.Sch
 }
 
 func (r SubscriptionCostManagementViewResource) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			var config SubscriptionCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := views.NewScopedViewID(config.SubId, config.Name)
+
+			existing, err := client.GetByScope(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			accumulated := views.AccumulatedTypeFalse
+			if config.Accumulated {
+				accumulated = views.AccumulatedTypeTrue
+			}
+
+			props := views.View{
+				Properties: &views.ViewProperties{
+					Accumulated: pointer.To(accumulated),
+					DisplayName: pointer.To(config.DisplayName),
+					Chart:       pointer.To(views.ChartType(config.ChartType)),
+					Query: &views.ReportConfigDefinition{
+						DataSet:   expandDatasetFromModel(config.Dataset),
+						Timeframe: views.ReportTimeframeType(config.Timeframe),
+						Type:      views.ReportTypeUsage,
+					},
+					Kpis:   expandKpisFromModel(config.Kpi),
+					Pivots: expandPivotsFromModel(config.Pivot),
+				},
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r SubscriptionCostManagementViewResource) Read() sdk.ResourceFunc {
-	return r.base.readFunc("subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := SubscriptionCostManagementViewModel{
+				Name:  id.ViewName,
+				SubId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					state.ChartType = pointer.FromEnum(props.Chart)
+					state.DisplayName = pointer.From(props.DisplayName)
+
+					state.Accumulated = views.AccumulatedTypeTrue == pointer.From(props.Accumulated)
+
+					state.Kpi = flattenKpisToModel(props.Kpis)
+					state.Pivot = flattenPivotsToModel(props.Pivots)
+
+					if query := props.Query; query != nil {
+						state.Timeframe = string(query.Timeframe)
+						state.ReportType = string(query.Type)
+						if query.DataSet != nil {
+							state.Dataset = flattenDatasetToModel(query.DataSet)
+						}
+					}
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r SubscriptionCostManagementViewResource) Delete() sdk.ResourceFunc {
@@ -64,5 +180,67 @@ func (r SubscriptionCostManagementViewResource) Delete() sdk.ResourceFunc {
 }
 
 func (r SubscriptionCostManagementViewResource) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config SubscriptionCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Update operation requires latest eTag to be set in the request.
+			existing, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			model := existing.Model
+
+			if model != nil {
+				if model.ETag == nil {
+					return fmt.Errorf("add %s: etag was nil", *id)
+				}
+			}
+
+			if model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+			}
+
+			if metadata.ResourceData.HasChange("display_name") {
+				model.Properties.DisplayName = pointer.To(config.DisplayName)
+			}
+
+			if metadata.ResourceData.HasChange("chart_type") {
+				model.Properties.Chart = pointer.To(views.ChartType(config.ChartType))
+			}
+
+			if metadata.ResourceData.HasChange("dataset") {
+				model.Properties.Query.DataSet = expandDatasetFromModel(config.Dataset)
+			}
+
+			if metadata.ResourceData.HasChange("timeframe") {
+				model.Properties.Query.Timeframe = views.ReportTimeframeType(config.Timeframe)
+			}
+
+			if metadata.ResourceData.HasChange("kpi") {
+				model.Properties.Kpis = expandKpisFromModel(config.Kpi)
+			}
+
+			if metadata.ResourceData.HasChange("pivot") {
+				model.Properties.Pivots = expandPivotsFromModel(config.Pivot)
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, *id, *model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/internal/services/costmanagement/view_resource_base.go
+++ b/internal/services/costmanagement/view_resource_base.go
@@ -9,13 +9,44 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+// Shared nested model structs for cost management view resources
+
+type CostManagementViewAggregationModel struct {
+	Name       string `tfschema:"name"`
+	ColumnName string `tfschema:"column_name"`
+}
+
+type CostManagementViewSortingModel struct {
+	Direction string `tfschema:"direction"`
+	Name      string `tfschema:"name"`
+}
+
+type CostManagementViewGroupingModel struct {
+	Type string `tfschema:"type"`
+	Name string `tfschema:"name"`
+}
+
+type CostManagementViewDatasetModel struct {
+	Granularity string                               `tfschema:"granularity"`
+	Aggregation []CostManagementViewAggregationModel `tfschema:"aggregation"`
+	Sorting     []CostManagementViewSortingModel     `tfschema:"sorting"`
+	Grouping    []CostManagementViewGroupingModel    `tfschema:"grouping"`
+}
+
+type CostManagementViewKpiModel struct {
+	Type string `tfschema:"type"`
+}
+
+type CostManagementViewPivotModel struct {
+	Name string `tfschema:"name"`
+	Type string `tfschema:"type"`
+}
 
 type costManagementViewBaseResource struct{}
 
@@ -166,106 +197,6 @@ func (br costManagementViewBaseResource) attributes() map[string]*pluginsdk.Sche
 	return map[string]*pluginsdk.Schema{}
 }
 
-func (br costManagementViewBaseResource) createFunc(resourceName, scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ViewsClient
-			id := views.NewScopedViewID(metadata.ResourceData.Get(scopeFieldName).(string), metadata.ResourceData.Get("name").(string))
-
-			existing, err := client.GetByScope(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-				}
-			}
-
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError(resourceName, id.ID())
-			}
-
-			accumulated := views.AccumulatedTypeFalse
-			if accumulatedRaw := metadata.ResourceData.Get("accumulated").(bool); accumulatedRaw {
-				accumulated = views.AccumulatedTypeTrue
-			}
-
-			props := views.View{
-				Properties: &views.ViewProperties{
-					Accumulated: pointer.To(accumulated),
-					DisplayName: pointer.To(metadata.ResourceData.Get("display_name").(string)),
-					Chart:       pointer.To(views.ChartType(metadata.ResourceData.Get("chart_type").(string))),
-					Query: &views.ReportConfigDefinition{
-						DataSet:   expandDataset(metadata.ResourceData.Get("dataset").([]interface{})),
-						Timeframe: views.ReportTimeframeType(metadata.ResourceData.Get("timeframe").(string)),
-						Type:      views.ReportTypeUsage,
-					},
-					Kpis:   expandKpis(metadata.ResourceData.Get("kpi").([]interface{})),
-					Pivots: expandPivots(metadata.ResourceData.Get("pivot").([]interface{})),
-				},
-			}
-
-			if _, err = client.CreateOrUpdateByScope(ctx, id, props); err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
-			}
-
-			metadata.SetID(id)
-			return nil
-		},
-	}
-}
-
-func (br costManagementViewBaseResource) readFunc(scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 5 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ViewsClient
-
-			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			resp, err := client.GetByScope(ctx, *id)
-			if err != nil {
-				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
-				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
-			}
-
-			metadata.ResourceData.Set("name", id.ViewName)
-			// lintignore:R001
-			metadata.ResourceData.Set(scopeFieldName, id.Scope)
-
-			if model := resp.Model; model != nil {
-				if props := model.Properties; props != nil {
-					metadata.ResourceData.Set("chart_type", string(pointer.From(props.Chart)))
-
-					accumulated := false
-					if props.Accumulated != nil {
-						accumulated = views.AccumulatedTypeTrue == *props.Accumulated
-					}
-					metadata.ResourceData.Set("accumulated", accumulated)
-
-					metadata.ResourceData.Set("display_name", props.DisplayName)
-					metadata.ResourceData.Set("kpi", flattenKpis(props.Kpis))
-					metadata.ResourceData.Set("pivot", flattenPivots(props.Pivots))
-
-					if query := props.Query; query != nil {
-						metadata.ResourceData.Set("timeframe", string(query.Timeframe))
-						metadata.ResourceData.Set("report_type", string(query.Type))
-						if query.DataSet != nil {
-							metadata.ResourceData.Set("dataset", flattenDataset(query.DataSet))
-						}
-					}
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
 func (br costManagementViewBaseResource) deleteFunc() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -286,284 +217,163 @@ func (br costManagementViewBaseResource) deleteFunc() sdk.ResourceFunc {
 	}
 }
 
-func (br costManagementViewBaseResource) updateFunc() sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ViewsClient
+// Typed model expand/flatten helpers
 
-			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			// Update operation requires latest eTag to be set in the request.
-			existing, err := client.GetByScope(ctx, *id)
-			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
-			}
-			model := existing.Model
-
-			if model != nil {
-				if model.ETag == nil {
-					return fmt.Errorf("add %s: etag was nil", *id)
-				}
-			}
-
-			if model.Properties == nil {
-				return fmt.Errorf("retreiving properties for %s for update: %+v", *id, err)
-			}
-
-			if metadata.ResourceData.HasChange("display_name") {
-				model.Properties.DisplayName = pointer.To(metadata.ResourceData.Get("display_name").(string))
-			}
-
-			if metadata.ResourceData.HasChange("chart_type") {
-				model.Properties.Chart = pointer.To(views.ChartType(metadata.ResourceData.Get("chart_type").(string)))
-			}
-
-			if metadata.ResourceData.HasChange("dataset") {
-				model.Properties.Query.DataSet = expandDataset(metadata.ResourceData.Get("dataset").([]interface{}))
-			}
-			if metadata.ResourceData.HasChange("timeframe") {
-				model.Properties.Query.Timeframe = views.ReportTimeframeType(metadata.ResourceData.Get("timeframe").(string))
-			}
-
-			if metadata.ResourceData.HasChange("kpi") {
-				model.Properties.Kpis = expandKpis(metadata.ResourceData.Get("kpi").([]interface{}))
-			}
-
-			if metadata.ResourceData.HasChange("pivot") {
-				model.Properties.Pivots = expandPivots(metadata.ResourceData.Get("pivot").([]interface{}))
-			}
-
-			if _, err = client.CreateOrUpdateByScope(ctx, *id, *model); err != nil {
-				return fmt.Errorf("updating %s: %+v", *id, err)
-			}
-
-			return nil
-		},
-	}
-}
-
-func expandDataset(input []interface{}) *views.ReportConfigDataset {
-	if len(input) == 0 || input[0] == nil {
+func expandDatasetFromModel(input []CostManagementViewDatasetModel) *views.ReportConfigDataset {
+	if len(input) == 0 {
 		return nil
 	}
 
-	attrs := input[0].(map[string]interface{})
+	ds := input[0]
 	dataset := &views.ReportConfigDataset{
-		Granularity: pointer.To(views.ReportGranularityType(attrs["granularity"].(string))),
+		Granularity: pointer.To(views.ReportGranularityType(ds.Granularity)),
 	}
 
-	if aggregation := attrs["aggregation"].(*pluginsdk.Set).List(); len(aggregation) > 0 {
-		dataset.Aggregation = expandAggregation(aggregation)
+	if len(ds.Aggregation) > 0 {
+		aggregation := map[string]views.ReportConfigAggregation{}
+		for _, a := range ds.Aggregation {
+			aggregation[a.Name] = views.ReportConfigAggregation{
+				Name:     a.ColumnName,
+				Function: views.FunctionTypeSum,
+			}
+		}
+		dataset.Aggregation = &aggregation
 	}
 
-	if sorting := attrs["sorting"].([]interface{}); len(sorting) > 0 {
-		dataset.Sorting = expandSorting(sorting)
+	if len(ds.Sorting) > 0 {
+		sorting := make([]views.ReportConfigSorting, 0)
+		for _, s := range ds.Sorting {
+			sorting = append(sorting, views.ReportConfigSorting{
+				Direction: pointer.To(views.ReportConfigSortingType(s.Direction)),
+				Name:      s.Name,
+			})
+		}
+		dataset.Sorting = &sorting
 	}
 
-	if grouping := attrs["grouping"].([]interface{}); len(grouping) > 0 {
-		dataset.Grouping = expandGrouping(grouping)
+	if len(ds.Grouping) > 0 {
+		grouping := make([]views.ReportConfigGrouping, 0)
+		for _, g := range ds.Grouping {
+			grouping = append(grouping, views.ReportConfigGrouping{
+				Type: views.QueryColumnType(g.Type),
+				Name: g.Name,
+			})
+		}
+		dataset.Grouping = &grouping
 	}
 
 	return dataset
 }
 
-func expandAggregation(input []interface{}) *map[string]views.ReportConfigAggregation {
-	outputSorting := map[string]views.ReportConfigAggregation{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputSorting
+func flattenDatasetToModel(input *views.ReportConfigDataset) []CostManagementViewDatasetModel {
+	if input == nil {
+		return []CostManagementViewDatasetModel{}
 	}
 
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		name := v["name"].(string)
-		outputSorting[name] = views.ReportConfigAggregation{
-			Name:     v["column_name"].(string),
-			Function: views.FunctionTypeSum,
+	ds := CostManagementViewDatasetModel{}
+
+	if input.Granularity != nil {
+		ds.Granularity = string(*input.Granularity)
+	}
+
+	if input.Aggregation != nil {
+		aggregation := make([]CostManagementViewAggregationModel, 0)
+		for name, item := range *input.Aggregation {
+			aggregation = append(aggregation, CostManagementViewAggregationModel{
+				Name:       name,
+				ColumnName: item.Name,
+			})
 		}
+		ds.Aggregation = aggregation
 	}
 
-	return &outputSorting
+	if input.Sorting != nil {
+		sorting := make([]CostManagementViewSortingModel, 0)
+		for _, item := range *input.Sorting {
+			if item.Direction == nil {
+				continue
+			}
+			sorting = append(sorting, CostManagementViewSortingModel{
+				Name:      item.Name,
+				Direction: string(*item.Direction),
+			})
+		}
+		ds.Sorting = sorting
+	}
+
+	if input.Grouping != nil {
+		grouping := make([]CostManagementViewGroupingModel, 0)
+		for _, item := range *input.Grouping {
+			grouping = append(grouping, CostManagementViewGroupingModel{
+				Name: item.Name,
+				Type: string(item.Type),
+			})
+		}
+		ds.Grouping = grouping
+	}
+
+	return []CostManagementViewDatasetModel{ds}
 }
 
-func expandGrouping(input []interface{}) *[]views.ReportConfigGrouping {
-	outputGrouping := []views.ReportConfigGrouping{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputGrouping
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputGrouping = append(outputGrouping, views.ReportConfigGrouping{
-			Type: views.QueryColumnType(v["type"].(string)),
-			Name: v["name"].(string),
-		})
-	}
-
-	return &outputGrouping
-}
-
-func expandSorting(input []interface{}) *[]views.ReportConfigSorting {
-	outputSorting := []views.ReportConfigSorting{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputSorting
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputSorting = append(outputSorting, views.ReportConfigSorting{
-			Direction: pointer.To(views.ReportConfigSortingType(v["direction"].(string))),
-			Name:      v["name"].(string),
-		})
-	}
-
-	return &outputSorting
-}
-
-func expandKpis(input []interface{}) *[]views.KpiProperties {
-	outputKpis := []views.KpiProperties{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputKpis
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputKpis = append(outputKpis, views.KpiProperties{
-			Type:    pointer.To(views.KpiTypeType(v["type"].(string))),
+func expandKpisFromModel(input []CostManagementViewKpiModel) *[]views.KpiProperties {
+	kpis := make([]views.KpiProperties, 0)
+	for _, k := range input {
+		kpis = append(kpis, views.KpiProperties{
+			Type:    pointer.To(views.KpiTypeType(k.Type)),
 			Enabled: pointer.To(true),
 		})
 	}
-
-	return &outputKpis
+	return &kpis
 }
 
-func expandPivots(input []interface{}) *[]views.PivotProperties {
-	outputPivots := []views.PivotProperties{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputPivots
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputPivots = append(outputPivots, views.PivotProperties{
-			Type: pointer.To(views.PivotTypeType(v["type"].(string))),
-			Name: pointer.To((v["name"].(string))),
-		})
-	}
-
-	return &outputPivots
-}
-
-func flattenKpis(input *[]views.KpiProperties) []interface{} {
-	outputKpis := []interface{}{}
+func flattenKpisToModel(input *[]views.KpiProperties) []CostManagementViewKpiModel {
 	if input == nil || len(*input) == 0 {
-		return outputKpis
+		return []CostManagementViewKpiModel{}
 	}
 
+	result := make([]CostManagementViewKpiModel, 0)
 	for _, item := range *input {
 		kpiType := ""
 		if v := item.Type; v != nil && item.Enabled != nil && *item.Enabled {
 			kpiType = string(*v)
 		}
-
-		outputKpis = append(outputKpis, map[string]interface{}{
-			"type": kpiType,
+		result = append(result, CostManagementViewKpiModel{
+			Type: kpiType,
 		})
 	}
-
-	return outputKpis
+	return result
 }
 
-func flattenPivots(input *[]views.PivotProperties) []interface{} {
-	outputPivots := []interface{}{}
+func expandPivotsFromModel(input []CostManagementViewPivotModel) *[]views.PivotProperties {
+	pivots := make([]views.PivotProperties, 0)
+	for _, p := range input {
+		pivots = append(pivots, views.PivotProperties{
+			Type: pointer.To(views.PivotTypeType(p.Type)),
+			Name: pointer.To(p.Name),
+		})
+	}
+	return &pivots
+}
+
+func flattenPivotsToModel(input *[]views.PivotProperties) []CostManagementViewPivotModel {
 	if input == nil || len(*input) == 0 {
-		return outputPivots
+		return []CostManagementViewPivotModel{}
 	}
 
+	result := make([]CostManagementViewPivotModel, 0)
 	for _, item := range *input {
 		pivotType := ""
 		if v := item.Type; v != nil {
 			pivotType = string(*v)
 		}
-
 		name := ""
 		if p := item.Name; p != nil {
 			name = *p
 		}
-
-		outputPivots = append(outputPivots, map[string]interface{}{
-			"name": name,
-			"type": pivotType,
+		result = append(result, CostManagementViewPivotModel{
+			Name: name,
+			Type: pivotType,
 		})
 	}
-
-	return outputPivots
-}
-
-func flattenDataset(input *views.ReportConfigDataset) []interface{} {
-	outputDataset := map[string]interface{}{
-		"aggregation": flattenAggregation(input.Aggregation),
-		"sorting":     flattenSorting(input.Sorting),
-		"grouping":    flattenGrouping(input.Grouping),
-	}
-
-	if input.Granularity != nil {
-		outputDataset["granularity"] = string(*input.Granularity)
-	}
-
-	return []interface{}{outputDataset}
-}
-
-func flattenAggregation(input *map[string]views.ReportConfigAggregation) []interface{} {
-	outputAggregations := []interface{}{}
-	if input == nil || len(*input) == 0 {
-		return outputAggregations
-	}
-
-	for name, item := range *input {
-		outputAggregations = append(outputAggregations, map[string]interface{}{
-			"name":        name,
-			"column_name": item.Name,
-		})
-	}
-
-	return outputAggregations
-}
-
-func flattenGrouping(input *[]views.ReportConfigGrouping) []interface{} {
-	outputGroupings := []interface{}{}
-	if input == nil || len(*input) == 0 {
-		return outputGroupings
-	}
-
-	for _, item := range *input {
-		outputGroupings = append(outputGroupings, map[string]interface{}{
-			"name": item.Name,
-			"type": string(item.Type),
-		})
-	}
-
-	return outputGroupings
-}
-
-func flattenSorting(input *[]views.ReportConfigSorting) []interface{} {
-	outputSortings := []interface{}{}
-	if input == nil || len(*input) == 0 {
-		return outputSortings
-	}
-
-	for _, item := range *input {
-		if item.Direction == nil {
-			continue
-		}
-		outputSortings = append(outputSortings, map[string]interface{}{
-			"name":      item.Name,
-			"direction": string(*item.Direction),
-		})
-	}
-
-	return outputSortings
+	return result
 }

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -133,6 +133,9 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 					int(workspaces.CapacityReservationLevelOneThousand),
 					int(workspaces.CapacityReservationLevelTwoThousand),
 					int(workspaces.CapacityReservationLevelFiveThousand),
+					int(workspaces.CapacityReservationLevelOneZeroThousand),
+					int(workspaces.CapacityReservationLevelTwoFiveThousand),
+					int(workspaces.CapacityReservationLevelFiveZeroThousand),
 				}),
 			},
 

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -175,7 +175,7 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 						"request_message": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 140),
+							ValidateFunc: validation.StringLenBetween(0, 140),
 						},
 						"private_ip_address": {
 							Type:     pluginsdk.TypeString,
@@ -304,11 +304,6 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 				// If this is not a manual connection and the message is set return an error since this does not make sense.
 				if !privateServiceConnection["is_manual_connection"].(bool) && privateServiceConnection["request_message"].(string) != "" {
 					return fmt.Errorf(`"private_service_connection":%q is invalid, the "request_message" attribute cannot be set if the "is_manual_connection" attribute is "false"`, name)
-				}
-
-				// If this is a manual connection and the message isn't set return an error.
-				if privateServiceConnection["is_manual_connection"].(bool) && strings.TrimSpace(privateServiceConnection["request_message"].(string)) == "" {
-					return fmt.Errorf(`"private_service_connection":%q is invalid, the "request_message" attribute must not be empty`, name)
 				}
 			}
 			return nil

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -125,10 +125,6 @@ func TestAccPrivateEndpoint_invalidRequestMessage(t *testing.T) {
 			Config:      r.invalidAtuoWithRequestMessage(data),
 			ExpectError: regexp.MustCompile(`the "request_message" attribute cannot be set if the "is_manual_connection" attribute is "false"`),
 		},
-		{
-			Config:      r.invalidManualWithoutRequestMessage(data),
-			ExpectError: regexp.MustCompile(`the "request_message" attribute must not be empty`),
-		},
 	})
 }
 
@@ -596,25 +592,6 @@ resource "azurerm_private_endpoint" "test" {
     name                           = azurerm_private_link_service.test.name
     is_manual_connection           = false
     request_message                = "foo"
-    private_connection_resource_id = azurerm_private_link_service.test.id
-  }
-}
-`, r.template(data, r.serviceAutoApprove(data)), data.RandomInteger)
-}
-
-func (r PrivateEndpointResource) invalidManualWithoutRequestMessage(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_private_endpoint" "test" {
-  name                = "acctest-privatelink-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  subnet_id           = azurerm_subnet.endpoint.id
-
-  private_service_connection {
-    name                           = azurerm_private_link_service.test.name
-    is_manual_connection           = true
     private_connection_resource_id = azurerm_private_link_service.test.id
   }
 }

--- a/internal/tools/document-fmt/data/resource.go
+++ b/internal/tools/document-fmt/data/resource.go
@@ -3,7 +3,10 @@
 
 package data
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 type ResourceType string
 
@@ -35,5 +38,5 @@ func (r ResourceType) String() string {
 }
 
 func expectedResourceCodePath(pattern string, name string, service Service, resourceType ResourceType) string {
-	return fmt.Sprintf(pattern, service.Path, name, ResourceTypeToFileSuffix[resourceType])
+	return filepath.FromSlash(fmt.Sprintf(pattern, service.Path, name, ResourceTypeToFileSuffix[resourceType]))
 }

--- a/internal/tools/document-fmt/data/service.go
+++ b/internal/tools/document-fmt/data/service.go
@@ -6,6 +6,7 @@ package data
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"unicode"
 
@@ -56,7 +57,7 @@ func NewService(fs afero.Fs, providerDir string, providerServiceRegistration any
 	}
 
 	for _, n := range names {
-		path := fmt.Sprintf(serviceDirPattern, providerDir, n)
+		path := filepath.FromSlash(fmt.Sprintf(serviceDirPattern, providerDir, n))
 		if util.DirExists(fs, path) {
 			return &Service{
 				Name: n,

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
     action                         = "Block"
 
     match_condition {
-      match_variable     = "RemoteAddr"
+      match_variable     = "SocketAddr"
       operator           = "IPMatch"
       negation_condition = false
       match_values       = ["10.0.1.0/24", "10.0.0.0/24"]
@@ -61,7 +61,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
     action                         = "Block"
 
     match_condition {
-      match_variable     = "RemoteAddr"
+      match_variable     = "SocketAddr"
       operator           = "IPMatch"
       negation_condition = false
       match_values       = ["192.168.1.0/24"]
@@ -203,6 +203,8 @@ A `custom_rule` block supports the following:
 A `match_condition` block supports the following:
 
 * `match_variable` - (Required) The request variable to compare with. Possible values are `Cookies`, `PostArgs`, `QueryString`, `RemoteAddr`, `RequestBody`, `RequestHeader`, `RequestMethod`, `RequestUri`, or `SocketAddr`.
+
+-> **Note:** `RemoteAddr` inspects the original client IP from the `X-Forwarded-For` header. Use `SocketAddr` when you need to match the source IP address seen by Front Door WAF.
 
 * `match_values` - (Required) Up to `600` possible values to match. Limit is in total across all `match_condition` blocks and `match_values` arguments. String value itself can be up to `256` characters in length.
 

--- a/website/docs/r/cost_anomaly_alert.html.markdown
+++ b/website/docs/r/cost_anomaly_alert.html.markdown
@@ -36,13 +36,13 @@ The following arguments are supported:
 
 * `email_addresses` - (Required) Specifies a list of email addresses which the Anomaly Alerts are send to.
 
-* `email_subject` - (Required) The email subject of the Cost Anomaly Alerts. Maximum length of the subject is 70.
+* `email_subject` - (Required) The email subject of the Cost Anomaly Alerts. Maximum length of the subject is 50.
 
 * `notification_email` - (Optional) The email address of the point of contact that should get the unsubscribe requests and notification emails.
 
 ---
 
-* `message` - (Optional) The message of the Cost Anomaly Alert. Maximum length of the message is 250.
+* `message` - (Optional) The message of the Cost Anomaly Alert. Maximum length of the message is 100.
 
 ## Attributes Reference
 

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `internet_query_enabled` - (Optional) Should the Log Analytics Workspace support querying over the Public Internet? Defaults to `true`.
 
-* `reservation_capacity_in_gb_per_day` - (Optional) The capacity reservation level in GB for this workspace. Possible values are `100`, `200`, `300`, `400`, `500`, `1000`, `2000` and `5000`.
+* `reservation_capacity_in_gb_per_day` - (Optional) The capacity reservation level in GB for this workspace. Possible values are `100`, `200`, `300`, `400`, `500`, `1000`, `2000`, `5000`, `10000`, `25000`, and `50000`.
 
 ~> **Note:** `reservation_capacity_in_gb_per_day` can only be used when the `sku` is set to `CapacityReservation`.
 


### PR DESCRIPTION
## Description

Fixes hashicorp/terraform-provider-azurerm#32206

The `ValidateFunc` (`StringLenBetween(1, 140)`) and `CustomizeDiff` on `request_message` were more restrictive than what Azure API requires. Azure accepts empty or omitted `requestMessage` for manual private endpoint connections (confirmed via direct REST API testing — all 3 variants returned HTTP 200).

This caused a regression (introduced in PR #31705, shipped in v4.69.0) for users who imported existing private endpoints created without a request message — both validation paths blocked them with no valid escape route.

## Changes

- **`private_endpoint_resource.go`**: Relax `ValidateFunc` from `StringLenBetween(1, 140)` to `StringLenBetween(0, 140)`; remove `CustomizeDiff` check requiring non-empty `request_message` for manual connections
- **`private_endpoint_resource_test.go`**: Remove test step expecting 'must not be empty' error and unused helper function `invalidManualWithoutRequestMessage`

## Evidence

- **Tier 1**: Azure REST API (api-version 2024-05-01) accepts `PUT` with `requestMessage` omitted, empty string, or non-empty — all return HTTP 200
- **Tier 1**: Provider `ValidateFunc` blocks `request_message=''''` at plan time (reproduced)
- **Tier 1**: Provider `CustomizeDiff` blocks omitted `request_message` at plan time (reproduced)
- The `Expand` function (line ~819) already handles empty `request_message` correctly (only sets API field when non-empty)

## Compatibility

- **Non-breaking**: Users just upgrade the provider version, no HCL changes needed
- **terraform plan impact**: No drift. Previously blocked configs now pass validation. Already-working configs are unaffected.

## Testing

- `go build ./internal/services/network/` ✅
- `go vet ./internal/services/network/` ✅
- 2 rounds of independent code review (0 issues in final round)

## PR Scope

All changes within approved Plan scope. No scope drift. No AI infrastructure files included.