### PR TITLE
azurerm_private_endpoint - allow empty `request_message` for manual connections

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -175,7 +175,7 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 						"request_message": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 140),
+							ValidateFunc: validation.StringLenBetween(0, 140),
 						},
 						"private_ip_address": {
 							Type:     pluginsdk.TypeString,
@@ -304,11 +304,6 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 				// If this is not a manual connection and the message is set return an error since this does not make sense.
 				if !privateServiceConnection["is_manual_connection"].(bool) && privateServiceConnection["request_message"].(string) != "" {
 					return fmt.Errorf(`"private_service_connection":%q is invalid, the "request_message" attribute cannot be set if the "is_manual_connection" attribute is "false"`, name)
-				}
-
-				// If this is a manual connection and the message isn't set return an error.
-				if privateServiceConnection["is_manual_connection"].(bool) && strings.TrimSpace(privateServiceConnection["request_message"].(string)) == "" {
-					return fmt.Errorf(`"private_service_connection":%q is invalid, the "request_message" attribute must not be empty`, name)
 				}
 			}
 			return nil

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -125,10 +125,21 @@ func TestAccPrivateEndpoint_invalidRequestMessage(t *testing.T) {
 			Config:      r.invalidAtuoWithRequestMessage(data),
 			ExpectError: regexp.MustCompile(`the "request_message" attribute cannot be set if the "is_manual_connection" attribute is "false"`),
 		},
+	})
+}
+
+func TestAccPrivateEndpoint_manualWithoutRequestMessage(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_private_endpoint", "test")
+	r := PrivateEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.invalidManualWithoutRequestMessage(data),
-			ExpectError: regexp.MustCompile(`the "request_message" attribute must not be empty`),
+			Config: r.invalidManualWithoutRequestMessage(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
+		data.ImportStep(),
 	})
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes a bug where `azurerm_private_endpoint` rejects an empty or omitted `request_message` when `is_manual_connection = true`. The Azure API allows manual connections without a request message, but PR #31705 introduced overly restrictive plan-time validation that blocks this valid configuration.

**Root cause:** Two validation paths rejected empty `request_message` for manual connections:
1. `ValidateFunc: validation.StringLenBetween(1, 140)` — rejected empty strings at schema level
2. `CustomizeDiff` — explicitly checked for empty/whitespace-only `request_message` on manual connections

**Changes:**
- Relaxed `ValidateFunc` from `StringLenBetween(1, 140)` to `StringLenBetween(0, 140)` to allow empty strings
- Removed the `CustomizeDiff` check that required non-empty `request_message` for manual connections

This is a non-breaking change with no drift impact. This PR went through 2 rounds of independent code review, last round 0 issues.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

**Tests run locally:**
- `TestAccPrivateEndpoint_invalidRequestMessage` — PASSED (validates that `request_message` is still rejected for automatic connections)
- `TestAccPrivateEndpoint_manualWithoutRequestMessage` — PASSED in 276s (new test, validates manual connection without `request_message` succeeds and imports correctly)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_endpoint` - fix validation rejecting empty `request_message` when `is_manual_connection` is `true` [GH-32206]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32206


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
AI (GitHub Copilot) was used to assist with code generation, test writing, and PR creation. All changes were reviewed by independent sub-agent code review (2 rounds, last round 0 issues).

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
