### PR TITLE
azurerm_virtual_network, azurerm_subnet - fix number_of_ip_addresses comparison using math/big.Int

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -464,7 +464,7 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 				for _, existingAllocation := range *props.IPamPoolPrefixAllocations {
 					for _, expandedAllocation := range *expandedIPAddressPool {
 						if existingAllocation.Pool != nil && expandedAllocation.Pool != nil && strings.EqualFold(pointer.From(existingAllocation.Pool.Id), pointer.From(expandedAllocation.Pool.Id)) &&
-							existingAllocation.NumberOfIPAddresses != nil && expandedAllocation.NumberOfIPAddresses != nil && *existingAllocation.NumberOfIPAddresses > *expandedAllocation.NumberOfIPAddresses {
+							existingAllocation.NumberOfIPAddresses != nil && expandedAllocation.NumberOfIPAddresses != nil && numberOfIPAddressesDecreased(*existingAllocation.NumberOfIPAddresses, *expandedAllocation.NumberOfIPAddresses) {
 							return fmt.Errorf("`number_of_ip_addresses` cannot be decreased from %v to %v on pool: %v", *existingAllocation.NumberOfIPAddresses, *expandedAllocation.NumberOfIPAddresses, *expandedAllocation.Pool.Id)
 						}
 					}

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/big"
 	"regexp"
 	"strings"
 	"time"
@@ -545,7 +546,7 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 				for _, existingAllocation := range *payload.Properties.AddressSpace.IPamPoolPrefixAllocations {
 					for _, expandedAllocation := range *expandedIPAddressPool {
 						if existingAllocation.Pool != nil && expandedAllocation.Pool != nil && strings.EqualFold(pointer.From(existingAllocation.Pool.Id), pointer.From(expandedAllocation.Pool.Id)) &&
-							existingAllocation.NumberOfIPAddresses != nil && expandedAllocation.NumberOfIPAddresses != nil && *existingAllocation.NumberOfIPAddresses > *expandedAllocation.NumberOfIPAddresses {
+							existingAllocation.NumberOfIPAddresses != nil && expandedAllocation.NumberOfIPAddresses != nil && numberOfIPAddressesDecreased(*existingAllocation.NumberOfIPAddresses, *expandedAllocation.NumberOfIPAddresses) {
 							return fmt.Errorf("`number_of_ip_addresses` cannot be decreased from %v to %v on pool: %v", *existingAllocation.NumberOfIPAddresses, *expandedAllocation.NumberOfIPAddresses, *expandedAllocation.Pool.Id)
 						}
 					}
@@ -976,6 +977,19 @@ func flattenVirtualNetworkIPAddressPool(input *[]virtualnetworks.IPamPoolPrefixA
 	}
 
 	return outputs
+}
+
+// numberOfIPAddressesDecreased compares two numeric string values and returns true
+// if existing is greater than expanded (i.e., a decrease). Uses math/big.Int to
+// handle large IPv6 address counts correctly instead of lexicographic string comparison.
+func numberOfIPAddressesDecreased(existing, expanded string) bool {
+	existingVal, ok1 := new(big.Int).SetString(existing, 10)
+	expandedVal, ok2 := new(big.Int).SetString(expanded, 10)
+	if !ok1 || !ok2 {
+		log.Printf("[WARN] could not parse number_of_ip_addresses for comparison: existing=%q, expanded=%q", existing, expanded)
+		return false
+	}
+	return existingVal.Cmp(expandedVal) > 0
 }
 
 func flattenVirtualNetworkDDoSProtectionPlan(input *virtualnetworks.VirtualNetworkPropertiesFormat) []interface{} {

--- a/internal/services/network/virtual_network_resource_unit_test.go
+++ b/internal/services/network/virtual_network_resource_unit_test.go
@@ -1,0 +1,91 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package network
+
+import "testing"
+
+func TestNumberOfIPAddressesDecreased(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing string
+		expanded string
+		expected bool
+	}{
+		{
+			name:     "decrease from larger to smaller",
+			existing: "128",
+			expanded: "32",
+			expected: true,
+		},
+		{
+			name:     "increase from smaller to larger",
+			existing: "32",
+			expanded: "128",
+			expected: false,
+		},
+		{
+			name:     "equal values",
+			existing: "64",
+			expanded: "64",
+			expected: false,
+		},
+		{
+			name:     "lexicographic trap - increase looks like decrease",
+			existing: "9",
+			expanded: "10",
+			expected: false,
+		},
+		{
+			name:     "lexicographic trap - decrease looks like increase",
+			existing: "10",
+			expanded: "9",
+			expected: true,
+		},
+		{
+			name:     "large IPv6 address counts",
+			existing: "340282366920938463463374607431768211456",
+			expanded: "340282366920938463463374607431768211455",
+			expected: true,
+		},
+		{
+			name:     "large IPv6 address counts - increase",
+			existing: "340282366920938463463374607431768211455",
+			expanded: "340282366920938463463374607431768211456",
+			expected: false,
+		},
+		{
+			name:     "unparseable existing value",
+			existing: "abc",
+			expanded: "128",
+			expected: false,
+		},
+		{
+			name:     "unparseable expanded value",
+			existing: "128",
+			expanded: "xyz",
+			expected: false,
+		},
+		{
+			name:     "both unparseable",
+			existing: "foo",
+			expanded: "bar",
+			expected: false,
+		},
+		{
+			name:     "empty strings",
+			existing: "",
+			expanded: "",
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := numberOfIPAddressesDecreased(tc.existing, tc.expanded)
+			if result != tc.expected {
+				t.Errorf("numberOfIPAddressesDecreased(%q, %q) = %v, want %v", tc.existing, tc.expanded, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fix for #32223 — The update guard for `number_of_ip_addresses` in both `azurerm_virtual_network` and `azurerm_subnet` used Go's `>` operator on `*string` values, performing **lexicographic** comparison instead of **numeric** comparison. This caused incorrect behavior where, for example, `"32" > "128"` evaluated to `true` lexicographically but is `false` numerically.

This PR introduces a `numberOfIPAddressesDecreased()` helper function (in `virtual_network_resource.go`, called from both resources) that parses the string values using `math/big.Int` for correct arbitrary-precision numeric comparison. The helper also includes a `log.Printf` warning for unparseable values, defaulting to `false` (no decrease) in edge cases.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

This is a deterministic code logic fix (replacing string comparison with `math/big.Int` numeric comparison). The project compiles successfully. No acceptance test credentials are available, but the change is a straightforward correction of comparison logic that does not alter resource schema or API interactions.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_network` - fix `number_of_ip_addresses` comparison to use numeric instead of lexicographic ordering [GH-32223]
* `azurerm_subnet` - fix `number_of_ip_addresses` comparison to use numeric instead of lexicographic ordering [GH-32223]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32223


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
This fix was developed with AI/LLM assistance for code generation and analysis.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
