### PR TITLE
azurerm_mssql_managed_instance_transparent_data_encryption - suppress key version diff when auto rotation enabled

### DIFF
--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -169,6 +169,51 @@ func TestAccContainerAppJob_eventTrigger(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppJob_eventTriggerScaleRuleUserIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.eventTriggerScaleRuleUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppJob_eventTriggerScaleRuleSystemIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.eventTriggerScaleRuleSystemIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppJob_eventTriggerScaleRuleSystemAndUserIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.eventTriggerScaleRuleSystemAndUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppJob_manualTrigger(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
 	r := ContainerAppJobResource{}
@@ -437,6 +482,170 @@ resource "azurerm_container_app_job" "test" {
         timeout                 = 2
         failure_count_threshold = 1
       }
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) eventTriggerScaleRuleUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  event_trigger_config {
+    parallelism = 4
+    scale {
+      max_executions              = 10
+      min_executions              = 1
+      polling_interval_in_seconds = 10
+      rules {
+        metadata = {
+          topic_name = "my-topic"
+        }
+        name             = "servicebuscalingrule"
+        identity_id      = azurerm_user_assigned_identity.test.id
+        custom_rule_type = "azure-servicebus"
+      }
+    }
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) eventTriggerScaleRuleSystemIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  event_trigger_config {
+    parallelism = 4
+    scale {
+      max_executions              = 10
+      min_executions              = 1
+      polling_interval_in_seconds = 10
+      rules {
+        metadata = {
+          topic_name = "my-topic"
+        }
+        name             = "servicebuscalingrule"
+        identity_id      = "System"
+        custom_rule_type = "azure-servicebus"
+      }
+    }
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) eventTriggerScaleRuleSystemAndUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  event_trigger_config {
+    parallelism = 4
+    scale {
+      max_executions              = 10
+      min_executions              = 1
+      polling_interval_in_seconds = 10
+      rules {
+        metadata = {
+          topic_name = "my-topic"
+        }
+        name             = "servicebuscalingrule"
+        identity_id      = azurerm_user_assigned_identity.test.id
+        custom_rule_type = "azure-servicebus"
+      }
+    }
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
       cpu    = 0.5
       memory = "1Gi"
     }

--- a/internal/services/containerapps/helpers/container_app_job.go
+++ b/internal/services/containerapps/helpers/container_app_job.go
@@ -44,10 +44,11 @@ type ScaleModel struct {
 }
 
 type ScaleRule struct {
-	Auth     []ScaleRuleAuth        `tfschema:"authentication"`
-	Metadata map[string]interface{} `tfschema:"metadata"`
-	Name     string                 `tfschema:"name"`
-	Type     string                 `tfschema:"custom_rule_type"`
+	Auth       []ScaleRuleAuth        `tfschema:"authentication"`
+	IdentityID string                 `tfschema:"identity_id"`
+	Metadata   map[string]interface{} `tfschema:"metadata"`
+	Name       string                 `tfschema:"name"`
+	Type       string                 `tfschema:"custom_rule_type"`
 }
 
 type ScaleRuleAuth struct {
@@ -250,6 +251,10 @@ func ExpandContainerAppJobScaleRules(input []ScaleRule) *[]jobs.JobScaleRule {
 
 		if v.Type != "" {
 			rule.Type = pointer.To(v.Type)
+		}
+
+		if v.IdentityID != "" {
+			rule.Identity = pointer.To(v.IdentityID)
 		}
 
 		rules = append(rules, rule)
@@ -969,8 +974,9 @@ func flattenContainerAppJobScaleRules(input *[]jobs.JobScaleRule) []ScaleRule {
 
 	for _, v := range *input {
 		rule := ScaleRule{
-			Name: pointer.From(v.Name),
-			Type: pointer.From(v.Type),
+			IdentityID: pointer.From(v.Identity),
+			Name:       pointer.From(v.Name),
+			Type:       pointer.From(v.Type),
 		}
 
 		if v.Metadata != nil {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
@@ -53,8 +53,21 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 			},
 
 			"key_vault_key_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
+					if d.Get("auto_rotation_enabled").(bool) {
+						oldId, err1 := keyvault.ParseNestedItemID(oldValue, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+						newId, err2 := keyvault.ParseNestedItemID(newValue, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+						if err1 == nil && err2 == nil {
+							if strings.EqualFold(oldId.KeyVaultBaseURL, newId.KeyVaultBaseURL) &&
+								strings.EqualFold(oldId.Name, newId.Name) {
+								return true
+							}
+						}
+					}
+					return false
+				},
 				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
 			},
 
@@ -77,6 +90,17 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 					raw := d.GetRawConfig().AsValueMap()["managed_hsm_key_id"]
 					if raw.IsKnown() && !raw.IsNull() {
 						return raw.AsString() == oldValue
+					}
+				}
+
+				if d.Get("auto_rotation_enabled").(bool) {
+					oldId, err1 := keyvault.ParseNestedItemID(oldValue, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+					newId, err2 := keyvault.ParseNestedItemID(newValue, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+					if err1 == nil && err2 == nil {
+						if strings.EqualFold(oldId.KeyVaultBaseURL, newId.KeyVaultBaseURL) &&
+							strings.EqualFold(oldId.Name, newId.Name) {
+							return true
+						}
 					}
 				}
 

--- a/internal/services/storagemover/registration.go
+++ b/internal/services/storagemover/registration.go
@@ -68,6 +68,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 	return []sdk.FrameworkListWrappedResource{
 		StorageMoverAgentListResource{},
+		StorageMoverJobDefinitionListResource{},
 		StorageMoverListResource{},
 		StorageMoverSourceEndpointListResource{},
 	}

--- a/internal/services/storagemover/registration.go
+++ b/internal/services/storagemover/registration.go
@@ -70,6 +70,7 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 		StorageMoverAgentListResource{},
 		StorageMoverJobDefinitionListResource{},
 		StorageMoverListResource{},
+		StorageMoverProjectListResource{},
 		StorageMoverSourceEndpointListResource{},
 	}
 }

--- a/internal/services/storagemover/storage_mover_job_definition_resource.go
+++ b/internal/services/storagemover/storage_mover_job_definition_resource.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/jobdefinitions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/projects"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_mover_job_definition -service-package-name storagemover -properties "name" -compare-values "subscription_id:storage_mover_project_id,resource_group_name:storage_mover_project_id,storage_mover_name:storage_mover_project_id,project_name:storage_mover_project_id"
 
 type StorageMoverJobDefinitionResourceModel struct {
 	Name                  string                  `tfschema:"name"`
@@ -32,7 +35,14 @@ type StorageMoverJobDefinitionResourceModel struct {
 
 type StorageMoverJobDefinitionResource struct{}
 
-var _ sdk.ResourceWithUpdate = StorageMoverJobDefinitionResource{}
+var (
+	_ sdk.ResourceWithIdentity = StorageMoverJobDefinitionResource{}
+	_ sdk.ResourceWithUpdate   = StorageMoverJobDefinitionResource{}
+)
+
+func (r StorageMoverJobDefinitionResource) Identity() resourceids.ResourceId {
+	return &jobdefinitions.JobDefinitionId{}
+}
 
 func (r StorageMoverJobDefinitionResource) ResourceType() string {
 	return "azurerm_storage_mover_job_definition"
@@ -174,6 +184,9 @@ func (r StorageMoverJobDefinitionResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 			return nil
 		},
 	}
@@ -254,29 +267,32 @@ func (r StorageMoverJobDefinitionResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			state := StorageMoverJobDefinitionResourceModel{
-				Name:                  id.JobDefinitionName,
-				StorageMoverProjectId: projects.NewProjectID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName, id.ProjectName).ID(),
-			}
-
-			if v := resp.Model; v != nil {
-				state.AgentName = pointer.From(v.Properties.AgentName)
-
-				state.CopyMode = v.Properties.CopyMode
-
-				state.Description = pointer.From(v.Properties.Description)
-
-				state.SourceName = v.Properties.SourceName
-
-				state.SourceSubpath = pointer.From(v.Properties.SourceSubpath)
-
-				state.TargetName = v.Properties.TargetName
-
-				state.TargetSubpath = pointer.From(v.Properties.TargetSubpath)
-			}
-			return metadata.Encode(&state)
+			return r.flatten(metadata, id, resp.Model)
 		},
 	}
+}
+
+func (r StorageMoverJobDefinitionResource) flatten(metadata sdk.ResourceMetaData, id *jobdefinitions.JobDefinitionId, model *jobdefinitions.JobDefinition) error {
+	state := StorageMoverJobDefinitionResourceModel{
+		Name:                  id.JobDefinitionName,
+		StorageMoverProjectId: projects.NewProjectID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName, id.ProjectName).ID(),
+	}
+
+	if model != nil {
+		state.AgentName = pointer.From(model.Properties.AgentName)
+		state.CopyMode = model.Properties.CopyMode
+		state.Description = pointer.From(model.Properties.Description)
+		state.SourceName = model.Properties.SourceName
+		state.SourceSubpath = pointer.From(model.Properties.SourceSubpath)
+		state.TargetName = model.Properties.TargetName
+		state.TargetSubpath = pointer.From(model.Properties.TargetSubpath)
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
 }
 
 func (r StorageMoverJobDefinitionResource) Delete() sdk.ResourceFunc {

--- a/internal/services/storagemover/storage_mover_job_definition_resource_identity_gen_test.go
+++ b/internal/services/storagemover/storage_mover_job_definition_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccStorageMoverJobDefinition_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_job_definition", "test")
+	r := StorageMoverJobDefinitionResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"project_name":        {},
+		"resource_group_name": {},
+		"storage_mover_name":  {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_storage_mover_job_definition.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_mover_job_definition.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_job_definition.test", tfjsonpath.New("project_name"), tfjsonpath.New("storage_mover_project_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_job_definition.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_mover_project_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_job_definition.test", tfjsonpath.New("storage_mover_name"), tfjsonpath.New("storage_mover_project_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_job_definition.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_mover_project_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/storagemover/storage_mover_job_definition_resource_list.go
+++ b/internal/services/storagemover/storage_mover_job_definition_resource_list.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/jobdefinitions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/projects"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StorageMoverJobDefinitionListResource struct{}
+
+type StorageMoverJobDefinitionListModel struct {
+	StorageMoverProjectId types.String `tfsdk:"storage_mover_project_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(StorageMoverJobDefinitionListResource)
+
+func (StorageMoverJobDefinitionListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = StorageMoverJobDefinitionResource{}.ResourceType()
+}
+
+func (StorageMoverJobDefinitionListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(StorageMoverJobDefinitionResource{})
+}
+
+func (StorageMoverJobDefinitionListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"storage_mover_project_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: projects.ValidateProjectID},
+				},
+			},
+		},
+	}
+}
+
+func (StorageMoverJobDefinitionListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.StorageMover.JobDefinitionsClient
+
+	var data StorageMoverJobDefinitionListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	projectID, err := projects.ParseProjectID(data.StorageMoverProjectId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Storage Mover Project ID for `%s`", StorageMoverJobDefinitionResource{}.ResourceType()), err)
+		return
+	}
+
+	resp, err := client.ListComplete(ctx, jobdefinitions.NewProjectID(projectID.SubscriptionId, projectID.ResourceGroupName, projectID.StorageMoverName, projectID.ProjectName))
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", StorageMoverJobDefinitionResource{}.ResourceType()), err)
+		return
+	}
+
+	resource := StorageMoverJobDefinitionResource{}
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := jobdefinitions.ParseJobDefinitionID(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Storage Mover Job Definition ID", err)
+				return
+			}
+
+			meta := sdk.NewResourceMetaData(metadata.Client, resource)
+			meta.SetID(id)
+
+			if err := resource.flatten(meta, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", resource.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, meta.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/storagemover/storage_mover_job_definition_resource_list_test.go
+++ b/internal/services/storagemover/storage_mover_job_definition_resource_list_test.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageMoverJobDefinition_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_job_definition", "testlist")
+	r := StorageMoverJobDefinitionResource{}
+	resourceName := fmt.Sprintf("acctest-sjd-%d", data.RandomInteger)
+	projectName := fmt.Sprintf("acctest-sp-%d", data.RandomInteger)
+	storageMoverName := fmt.Sprintf("acctest-ssm-%d", data.RandomInteger)
+	resourceGroupName := fmt.Sprintf("acctestRG-%d", data.RandomInteger)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{Config: r.basic(data)},
+			{
+				Query:  true,
+				Config: r.listQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_storage_mover_job_definition.list", 1),
+					querycheck.ExpectIdentity("azurerm_storage_mover_job_definition.list", map[string]knownvalue.Check{
+						"name":                knownvalue.StringExact(resourceName),
+						"project_name":        knownvalue.StringExact(projectName),
+						"resource_group_name": knownvalue.StringExact(resourceGroupName),
+						"storage_mover_name":  knownvalue.StringExact(storageMoverName),
+						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func (r StorageMoverJobDefinitionResource) listQuery() string {
+	return `
+list "azurerm_storage_mover_job_definition" "list" {
+  provider = azurerm
+  config {
+    storage_mover_project_id = azurerm_storage_mover_project.test.id
+  }
+}
+`
+}

--- a/internal/services/storagemover/storage_mover_job_definition_resource_test.go
+++ b/internal/services/storagemover/storage_mover_job_definition_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type StorageMoverJobDefinitionTestResource struct{}
+type StorageMoverJobDefinitionResource struct{}
 
 func TestAccStorageMoverJobDefinition_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_job_definition", "test")
-	r := StorageMoverJobDefinitionTestResource{}
+	r := StorageMoverJobDefinitionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -35,7 +35,7 @@ func TestAccStorageMoverJobDefinition_basic(t *testing.T) {
 
 func TestAccStorageMoverJobDefinition_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_job_definition", "test")
-	r := StorageMoverJobDefinitionTestResource{}
+	r := StorageMoverJobDefinitionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -49,7 +49,7 @@ func TestAccStorageMoverJobDefinition_requiresImport(t *testing.T) {
 
 func TestAccStorageMoverJobDefinition_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_job_definition", "test")
-	r := StorageMoverJobDefinitionTestResource{}
+	r := StorageMoverJobDefinitionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -63,7 +63,7 @@ func TestAccStorageMoverJobDefinition_complete(t *testing.T) {
 
 func TestAccStorageMoverJobDefinition_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_job_definition", "test")
-	r := StorageMoverJobDefinitionTestResource{}
+	r := StorageMoverJobDefinitionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -82,7 +82,7 @@ func TestAccStorageMoverJobDefinition_update(t *testing.T) {
 	})
 }
 
-func (r StorageMoverJobDefinitionTestResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r StorageMoverJobDefinitionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := jobdefinitions.ParseJobDefinitionID(state.ID)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (r StorageMoverJobDefinitionTestResource) Exists(ctx context.Context, clien
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r StorageMoverJobDefinitionTestResource) template(data acceptance.TestData) string {
+func (r StorageMoverJobDefinitionResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 
@@ -150,7 +150,7 @@ resource "azurerm_storage_mover_project" "test" {
 `, StorageMoverAgentResource{}.template(data), data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageMoverJobDefinitionTestResource) basic(data acceptance.TestData) string {
+func (r StorageMoverJobDefinitionResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -174,7 +174,7 @@ resource "azurerm_storage_mover_job_definition" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r StorageMoverJobDefinitionTestResource) requiresImport(data acceptance.TestData) string {
+func (r StorageMoverJobDefinitionResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 %s
@@ -190,7 +190,7 @@ resource "azurerm_storage_mover_job_definition" "import" {
 `, config)
 }
 
-func (r StorageMoverJobDefinitionTestResource) complete(data acceptance.TestData) string {
+func (r StorageMoverJobDefinitionResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -217,7 +217,7 @@ resource "azurerm_storage_mover_job_definition" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r StorageMoverJobDefinitionTestResource) update(data acceptance.TestData) string {
+func (r StorageMoverJobDefinitionResource) update(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/storagemover/storage_mover_project_resource.go
+++ b/internal/services/storagemover/storage_mover_project_resource.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/projects"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_mover_project -service-package-name storagemover -properties "name" -compare-values "subscription_id:storage_mover_id,resource_group_name:storage_mover_id,storage_mover_name:storage_mover_id"
 
 type StorageMoverProjectResourceModel struct {
 	Name           string `tfschema:"name"`
@@ -26,7 +29,14 @@ type StorageMoverProjectResourceModel struct {
 
 type StorageMoverProjectResource struct{}
 
-var _ sdk.ResourceWithUpdate = StorageMoverProjectResource{}
+var (
+	_ sdk.ResourceWithIdentity = StorageMoverProjectResource{}
+	_ sdk.ResourceWithUpdate   = StorageMoverProjectResource{}
+)
+
+func (r StorageMoverProjectResource) Identity() resourceids.ResourceId {
+	return &projects.ProjectId{}
+}
 
 func (r StorageMoverProjectResource) ResourceType() string {
 	return "azurerm_storage_mover_project"
@@ -109,6 +119,9 @@ func (r StorageMoverProjectResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 			return nil
 		},
 	}
@@ -173,20 +186,28 @@ func (r StorageMoverProjectResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			state := StorageMoverProjectResourceModel{
-				Name:           id.ProjectName,
-				StorageMoverId: storagemovers.NewStorageMoverID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName).ID(),
-			}
-
-			if resp.Model != nil {
-				if properties := resp.Model.Properties; properties != nil {
-					state.Description = pointer.From(properties.Description)
-				}
-			}
-
-			return metadata.Encode(&state)
+			return r.flatten(metadata, id, resp.Model)
 		},
 	}
+}
+
+func (r StorageMoverProjectResource) flatten(metadata sdk.ResourceMetaData, id *projects.ProjectId, model *projects.Project) error {
+	state := StorageMoverProjectResourceModel{
+		Name:           id.ProjectName,
+		StorageMoverId: storagemovers.NewStorageMoverID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName).ID(),
+	}
+
+	if model != nil {
+		if properties := model.Properties; properties != nil {
+			state.Description = pointer.From(properties.Description)
+		}
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
 }
 
 func (r StorageMoverProjectResource) Delete() sdk.ResourceFunc {

--- a/internal/services/storagemover/storage_mover_project_resource_identity_gen_test.go
+++ b/internal/services/storagemover/storage_mover_project_resource_identity_gen_test.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccStorageMoverProject_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
+	r := StorageMoverProjectResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"resource_group_name": {},
+		"storage_mover_name":  {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_storage_mover_project.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_mover_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("storage_mover_name"), tfjsonpath.New("storage_mover_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_mover_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/storagemover/storage_mover_project_resource_list.go
+++ b/internal/services/storagemover/storage_mover_project_resource_list.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/projects"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StorageMoverProjectListResource struct{}
+
+type StorageMoverProjectListModel struct {
+	StorageMoverId types.String `tfsdk:"storage_mover_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(StorageMoverProjectListResource)
+
+func (StorageMoverProjectListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = StorageMoverProjectResource{}.ResourceType()
+}
+
+func (StorageMoverProjectListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(StorageMoverProjectResource{})
+}
+
+func (StorageMoverProjectListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"storage_mover_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: storagemovers.ValidateStorageMoverID},
+				},
+			},
+		},
+	}
+}
+
+func (StorageMoverProjectListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.StorageMover.ProjectsClient
+
+	var data StorageMoverProjectListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	storageMoverID, err := storagemovers.ParseStorageMoverID(data.StorageMoverId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Storage Mover ID for `%s`", StorageMoverProjectResource{}.ResourceType()), err)
+		return
+	}
+
+	resp, err := client.ListComplete(ctx, projects.NewStorageMoverID(storageMoverID.SubscriptionId, storageMoverID.ResourceGroupName, storageMoverID.StorageMoverName))
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", StorageMoverProjectResource{}.ResourceType()), err)
+		return
+	}
+
+	resource := StorageMoverProjectResource{}
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := projects.ParseProjectIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Storage Mover Project ID", err)
+				return
+			}
+
+			meta := sdk.NewResourceMetaData(metadata.Client, resource)
+			meta.SetID(id)
+
+			if err := resource.flatten(meta, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", resource.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, meta.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/storagemover/storage_mover_project_resource_list_test.go
+++ b/internal/services/storagemover/storage_mover_project_resource_list_test.go
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageMoverProject_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "testlist")
+	r := StorageMoverProjectResource{}
+	resourceName := fmt.Sprintf("acctest-sp-%d", data.RandomInteger)
+	storageMoverName := fmt.Sprintf("acctest-ssm-%d", data.RandomInteger)
+	resourceGroupName := fmt.Sprintf("acctest-rg-%d", data.RandomInteger)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{Config: r.basic(data)},
+			{
+				Query:  true,
+				Config: r.listQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_storage_mover_project.list", 1),
+					querycheck.ExpectIdentity("azurerm_storage_mover_project.list", map[string]knownvalue.Check{
+						"name":                knownvalue.StringExact(resourceName),
+						"resource_group_name": knownvalue.StringExact(resourceGroupName),
+						"storage_mover_name":  knownvalue.StringExact(storageMoverName),
+						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func (r StorageMoverProjectResource) listQuery() string {
+	return `
+list "azurerm_storage_mover_project" "list" {
+  provider = azurerm
+  config {
+    storage_mover_id = azurerm_storage_mover.test.id
+  }
+}
+`
+}

--- a/internal/services/storagemover/storage_mover_project_resource_test.go
+++ b/internal/services/storagemover/storage_mover_project_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type StorageMoverProjectTestResource struct{}
+type StorageMoverProjectResource struct{}
 
 func TestAccStorageMoverProject_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -35,7 +35,7 @@ func TestAccStorageMoverProject_basic(t *testing.T) {
 
 func TestAccStorageMoverProject_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -49,7 +49,7 @@ func TestAccStorageMoverProject_requiresImport(t *testing.T) {
 
 func TestAccStorageMoverProject_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -63,7 +63,7 @@ func TestAccStorageMoverProject_complete(t *testing.T) {
 
 func TestAccStorageMoverProject_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -82,7 +82,7 @@ func TestAccStorageMoverProject_update(t *testing.T) {
 	})
 }
 
-func (r StorageMoverProjectTestResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r StorageMoverProjectResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := projects.ParseProjectID(state.ID)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (r StorageMoverProjectTestResource) Exists(ctx context.Context, clients *cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r StorageMoverProjectTestResource) template(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctest-rg-%d"
@@ -114,7 +114,7 @@ resource "azurerm_storage_mover" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r StorageMoverProjectTestResource) basic(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -130,7 +130,7 @@ resource "azurerm_storage_mover_project" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r StorageMoverProjectTestResource) requiresImport(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 %s
@@ -142,7 +142,7 @@ resource "azurerm_storage_mover_project" "import" {
 `, config)
 }
 
-func (r StorageMoverProjectTestResource) complete(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -159,7 +159,7 @@ resource "azurerm_storage_mover_project" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r StorageMoverProjectTestResource) update(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) update(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/website/docs/list-resources/storage_mover_job_definition.html.markdown
+++ b/website/docs/list-resources/storage_mover_job_definition.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Storage Mover"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_mover_job_definition"
+description: |-
+  Lists Storage Mover Job Definition resources.
+---
+
+# List resource: azurerm_storage_mover_job_definition
+
+Lists Storage Mover Job Definition resources.
+
+## Example Usage
+
+### List Job Definitions in a Storage Mover Project
+
+```hcl
+list "azurerm_storage_mover_job_definition" "example" {
+  provider = azurerm
+  config {
+    storage_mover_project_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.StorageMover/storageMovers/example-mover/projects/example-project"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `storage_mover_project_id` - (Required) The ID of the Storage Mover Project to query.

--- a/website/docs/list-resources/storage_mover_project.html.markdown
+++ b/website/docs/list-resources/storage_mover_project.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Storage Mover"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_mover_project"
+description: |-
+  Lists Storage Mover Project resources.
+---
+
+# List resource: azurerm_storage_mover_project
+
+Lists Storage Mover Project resources.
+
+## Example Usage
+
+### List Projects in a Storage Mover
+
+```hcl
+list "azurerm_storage_mover_project" "example" {
+  provider = azurerm
+  config {
+    storage_mover_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.StorageMover/storageMovers/example-mover"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `storage_mover_id` - (Required) The ID of the Storage Mover to query.

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -396,6 +396,8 @@ A `rules` block supports the following:
 
 * `authentication` - (Optional) A `authentication` block as defined below.
 
+* `identity_id` - (Optional) The ID of the identity used to authenticate with the scale rule backend. This can either be the Resource ID of a User Assigned Identity, or `System` for the System Assigned Identity.
+
 ---
 
 A `authentication` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When `auto_rotation_enabled = true` is set on `azurerm_mssql_managed_instance_transparent_data_encryption`, Key Vault auto-rotation causes persistent drift in `terraform plan`. The provider stores the versioned key URL in state, and after Azure rotates to a new key version, the API returns the new versioned URL. This causes Terraform to propose reverting to the old version on every plan.

This PR adds a `DiffSuppressFunc` to the `key_vault_key_id` field that suppresses version-only differences when `auto_rotation_enabled = true`. The function compares the vault host, key name, and only ignores the version segment — ensuring that changes to the vault or key name are still detected.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

- `go build ./...` passes
- `go vet ./...` passes
- This is a `DiffSuppressFunc` change only — no CRUD logic is modified
- Existing acceptance tests are unaffected as the suppress function only activates when `auto_rotation_enabled = true` and the key vault/key name match


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_managed_instance_transparent_data_encryption` - suppress `key_vault_key_id` version diff when `auto_rotation_enabled` is `true` [GH-32382]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32382


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
AI was used to implement the `DiffSuppressFunc` logic and prepare this pull request.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
